### PR TITLE
[FIX][BACKEND-7] Corrigido erro na busca por id de organizador

### DIFF
--- a/src/usecases/Organizador/FindOrganizadorById/FindOrganizadorByIdUseCase.ts
+++ b/src/usecases/Organizador/FindOrganizadorById/FindOrganizadorByIdUseCase.ts
@@ -7,7 +7,7 @@ export class FindOrganizadorByIdUseCase {
 
   async execute(id: number) {
 
-    return await this.organizadorRepository.findById(organizador);
+    return await this.organizadorRepository.findById(id);
 
   }
 


### PR DESCRIPTION
Foi corrigido um erro em produção em que a listagem por id de usuário organizador recebia um objeto ao invés de um number, foram removidos, também, imports desnecessários.