### PR TITLE
[FIX][BACKEND-8] corrigindo findById com orientadorDAO

### DIFF
--- a/src/domain/idao/IOrientadorDAO.ts
+++ b/src/domain/idao/IOrientadorDAO.ts
@@ -3,4 +3,5 @@ import { Orientador } from "../entities/Orientador";
 export interface IOrientadorDAO{
     findByCPF(CPF: string): Promise<Orientador | null>;
     save(orientador: Orientador): Promise<Orientador>;
+    findById(id: number): Promise<Orientador | null>;
 }

--- a/src/infra/dao/OrientadorDAO.ts
+++ b/src/infra/dao/OrientadorDAO.ts
@@ -25,6 +25,17 @@ export class OrientadorDAO implements IOrientadorDAO {
     return orientadorPrismaMapper.toDomain(userFromPrisma, orientadorFromPrisma);
   }
 
+  async findById(id: number): Promise<Orientador | null> {
+    const orientadorFromPrisma = await db.orientador.findUnique({
+      where: { id: id },
+      include: { address: true, user: true },
+    });
+
+    if (!orientadorFromPrisma) {
+      return null;
+    }
+    return orientadorPrismaMapper.toDomain(orientadorFromPrisma.user, orientadorFromPrisma);
+  }
   async save(orientador: Orientador): Promise<Orientador> {
     const { user, orientador: orientadorModel, address } = orientadorPrismaMapper.toPrismaModel(orientador);
     let userFromPrisma;


### PR DESCRIPTION
Este PR corrige a implementação do método `findById` no `OrientadorRepository`.

A alteração garante que o método utilize corretamente a camada `orientadorDAO` para realizar a busca pelo ID, resolvendo o comportamento incorreto da função.