### PR TITLE
[FEAT][BACKEND-12]: implementa busca de avaliador por id

### DIFF
--- a/src/domain/idao/IAvaliadorDAO.ts
+++ b/src/domain/idao/IAvaliadorDAO.ts
@@ -3,5 +3,6 @@ import { Avaliador } from "../entities/Avaliador";
 export interface IAvaliadorDAO{
     findByCPF(CPF: string): Promise<Avaliador | null>;
     save(avaliador: Avaliador): Promise<Avaliador>;
+    findById(id: number): Promise<Avaliador | null>;
 }
 

--- a/src/infra/dao/AvaliadorDAO.ts
+++ b/src/infra/dao/AvaliadorDAO.ts
@@ -4,6 +4,18 @@ import { db } from "../config/db/db";
 import { avaliadorPrismaMapper } from "../prismaMappers/AvaliadorPrismaMapper";
 
 export class AvaliadorDAO implements IAvaliadorDAO {
+  findById(id: number): Promise<Avaliador | null> {
+    return db.avaliador.findUnique({
+      where: { id: id },
+      include: { address: true, user: true },
+    }).then(avaliadorFromPrisma => {
+      if (!avaliadorFromPrisma || !avaliadorFromPrisma.user) {
+        return null;
+      }
+      return avaliadorPrismaMapper.toDomain(avaliadorFromPrisma.user, avaliadorFromPrisma);
+    });
+  }
+  
   async findByCPF(CPF: string): Promise<Avaliador | null> {
     const userFromPrisma = await db.user.findUnique({
       where: { CPF: CPF },

--- a/src/infra/repository/AvaliadorRepository.ts
+++ b/src/infra/repository/AvaliadorRepository.ts
@@ -4,6 +4,9 @@ import { AvaliadorDAO } from "../dao/AvaliadorDAO";
 
 export class AvaliadorRepository implements IAvaliadorRepository{
     constructor(private avaliadorDAO: AvaliadorDAO){}
+    findById(id: number): Promise<Avaliador | null> {
+        return this.avaliadorDAO.findById(id);
+    } 
 
     findByCPF(CPF: string): Promise<Avaliador | null> {
         return this.avaliadorDAO.findByCPF(CPF);


### PR DESCRIPTION
Este PR adiciona a funcionalidade para buscar um avaliador pelo ID.

Foram implementados os métodos `findById` na interface do DAO, na sua implementação e no repositório.

Closes #BACKEND-12